### PR TITLE
Redefine cursive dependency for better cross-platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 
 [dependencies]
 sqlite = "0.26.0"
-cursive = "0.17.0"
 languages-rs = { version = "0.2.0", features = ["with-toml"] }
 sys-locale = "0.2.0"
+
+[dependencies.cursive]
+version = "0.17.0"
+default-features = false
+features = ["crossterm-backend"]


### PR DESCRIPTION
Without defining a backend, there is an issue compiling in windows systems. To remedy this, a section is added to better define the dependency on cursive to use the crossterm-backend. This should be fine to work across different Unix/Unix-like systems, while also working on Windows system. If an issue occurs, will revert the fix in dev since supporting Unixes is a little more of a priority since this could also always be ran in WSL on windows.